### PR TITLE
Remote cluster fixes

### DIFF
--- a/carbonplan_trace/v1/inference.py
+++ b/carbonplan_trace/v1/inference.py
@@ -122,7 +122,7 @@ def convert_to_lat_lon(df, utm_zone_number, utm_zone_letter):
     return utm.to_latlon(df['x'], df['y'], int(utm_zone_number), utm_zone_letter)
 
 
-def load_xgb_model(model_path, fs, local_folder='./'):
+def load_xgb_model(model_path, fs):
     cwd = os.getcwd()
     if model_path.startswith('s3'):
         model_name = model_path.split('/')[-1]

--- a/carbonplan_trace/v1/landsat_preprocess.py
+++ b/carbonplan_trace/v1/landsat_preprocess.py
@@ -102,7 +102,7 @@ def grab_ds(item, bands_of_interest, cog_mask, utm_zone, utm_letter):
     ds = ds.assign_coords({'band': bands_of_interest})
     ds = ds.where(ds != 0)
     ds = ds.where(cog_mask < 2)
-    ds = ds.reflectance.to_dataset(dim='band')
+    ds = ds.reflectance.to_dataset(dim='band') * 0.0000275 - 0.2
     ds.attrs["utm_zone_number"] = utm_zone
     ds.attrs["utm_zone_letter"] = utm_letter
     ds = calc_NDVI(ds)
@@ -227,7 +227,7 @@ def grab_scene_coord_info(metadata):
     return lats, upper_right_corner_proj, upper_right_corner_coords
 
 
-def get_scene_utm_info(url):
+def get_scene_utm_info(url, json_client):
 
     '''
     Get the USGS-provided UTM zone and letter for the specific landsat scene
@@ -245,7 +245,6 @@ def get_scene_utm_info(url):
     '''
 
     metadata_url = url + '_MTL.json'
-    json_client = boto3.client('s3')
     data = json_client.get_object(
         Bucket='usgs-landsat', Key=metadata_url[18:], RequestPayer='requester'
     )
@@ -312,7 +311,6 @@ def calc_NDII(ds):
     nir = ds['SR_B4']
     swir = ds['SR_B5']
     ds['NDII'] = (nir - swir) / (nir + swir)
-    # ds['NDII'] = (ds['NDII']*1000).astype('int16')
 
     return ds
 
@@ -324,6 +322,7 @@ def scene_seasonal_average(
     access_key_id,
     secret_access_key,
     aws_session,
+    core_session,
     fs,
     write_bucket=None,
     bands_of_interest='all',
@@ -334,25 +333,9 @@ def scene_seasonal_average(
     mask each according to its time-specific cloud QA and then
     return average across all masked scenes
     '''
-    # aws_session = AWSSession(
-    #     boto3.Session(
-    #         aws_access_key_id=access_key_id,
-    #         aws_secret_access_key=secret_access_key,
-    #         region_name='us-west-2',
-    #     ),
-    #     requester_pays=True,
-    # )
-    # fs = S3FileSystem(
-    #     key=access_key_id, secret=secret_access_key, requester_pays=True, region='us-west-2'
-    # )
-
-    # with dask.config.set(
-    #     scheduler='single-threaded'
-    # ):  # this? **** #threads #single-threaded # threads??
-    #     with rio.Env(aws_session):
-    test_credentials(aws_session)
+    test_credentials(core_session)
     # all of this is just to get the right formatting stuff to access the scenes
-
+    test_client = core_session.client('s3')
     landsat_bucket = 's3://usgs-landsat/collection02/level-2/standard/tm/{}/{:03d}/{:03d}/'
     month_keys = {'JJA': ['06', '07', '08']}
     valid_files, ds_list = [], []
@@ -365,11 +348,10 @@ def scene_seasonal_average(
         for summer_datestamp in summer_datestamps:
             if summer_datestamp in scene_store:
                 valid_files.append(scene_store)
-    # ds_list = None
     for file in valid_files:
         scene_id = file[-40:]
         url = 's3://{}/{}'.format(file, scene_id)
-        utm_zone, utm_letter = get_scene_utm_info(url)
+        utm_zone, utm_letter = get_scene_utm_info(url, test_client)
         cloud_mask_url = url + '_SR_CLOUD_QA.TIF'
         cog_mask = cloud_qa(cloud_mask_url)
         ds_list.append(grab_ds(url, bands_of_interest, cog_mask, utm_zone, utm_letter))

--- a/carbonplan_trace/v1/landsat_preprocess.py
+++ b/carbonplan_trace/v1/landsat_preprocess.py
@@ -102,6 +102,8 @@ def grab_ds(item, bands_of_interest, cog_mask, utm_zone, utm_letter):
     ds = ds.assign_coords({'band': bands_of_interest})
     ds = ds.where(ds != 0)
     ds = ds.where(cog_mask < 2)
+    # scale the reflectance values according to recommendations from USGS
+    # https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2-level-2-science-products
     ds = ds.reflectance.to_dataset(dim='band') * 0.0000275 - 0.2
     ds.attrs["utm_zone_number"] = utm_zone
     ds.attrs["utm_zone_letter"] = utm_letter

--- a/carbonplan_trace/v1/utils.py
+++ b/carbonplan_trace/v1/utils.py
@@ -168,7 +168,6 @@ def write_parquet(df, out_path, access_key_id, secret_access_key):
         boto3_session=boto3.Session(
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
-            region='us-west-2',
         ),
     )
 

--- a/notebooks/inference.ipynb
+++ b/notebooks/inference.ipynb
@@ -15,28 +15,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from carbonplan_trace import version\n",
+    "\n",
+    "print(version)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
+    "\n",
+    "from pyproj import CRS\n",
     "import boto3\n",
     "from rasterio.session import AWSSession\n",
     "from s3fs import S3FileSystem\n",
-    "aws_session = AWSSession(boto3.Session(profile_name='default'), \n",
+    "aws_session = AWSSession(boto3.Session(),#profile_name='default'), \n",
     "                         requester_pays=True)\n",
-    "fs = S3FileSystem(profile='default', requester_pays=True)\n",
+    "fs = S3FileSystem(requester_pays=True) #profile='default', \n",
+    "import xgboost as xgb\n",
     "\n",
     "from osgeo.gdal import VSICurlClearCache\n",
-    "VSICurlClearCache() \n",
     "import rasterio as rio\n",
+    "import numpy as np\n",
     "import xarray as xr\n",
     "import dask\n",
     "import os\n",
     "import fsspec\n",
     "import geopandas as gpd\n",
-    "import regionmask as rm\n",
-    "from matplotlib.pyplot import imshow\n",
-    "from intake import open_stac_item_collection\n",
-    "import numcodecs\n",
-    "import numpy as np\n",
     "import rioxarray # for the extension to load\n",
     "import matplotlib.pyplot as plt\n",
     "import utm\n",
@@ -45,13 +54,9 @@
     "import json\n",
     "import zarr\n",
     "import awswrangler as wr\n",
-    "from dask.distributed import PipInstall\n",
     "from dask_gateway import Gateway\n",
-    "import fsspec\n",
-    "import xgboost as xgb \n",
-    "from carbonplan_trace.v1.landsat_preprocess import access_credentials\n",
-    "from carbonplan_trace.v1 import utils\n",
-    "from carbonplan_trace.v1.inference import predict"
+    "from carbonplan_trace.v1.landsat_preprocess import access_credentials, test_credentials\n",
+    "from carbonplan_trace.v1.inference import predict, predict_delayed"
    ]
   },
   {
@@ -62,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "cluster = \"local\"\n",
+    "cluster = \"remote\"  # \"remote\"\n",
     "if cluster == \"local\":\n",
     "    # spin up local cluster. must be on big enough machine\n",
     "    from dask.distributed import Client\n",
@@ -72,14 +77,36 @@
     "else:\n",
     "    gateway = Gateway()\n",
     "    options = gateway.cluster_options()\n",
-    "    options.environment = {\"AWS_REQUEST_PAYER\": \"requester\"}\n",
+    "    options.environment = {\n",
+    "        \"AWS_REQUEST_PAYER\": \"requester\",\n",
+    "        \"AWS_REGION_NAME\": \"us-west-2\",\n",
+    "    }\n",
     "    options.worker_cores = 2\n",
-    "    options.worker_memory = 48\n",
+    "    options.worker_memory = 60\n",
+    "    options.image = \"carbonplan/trace-python-notebook:main\"\n",
     "    cluster = gateway.new_cluster(cluster_options=options)\n",
-    "    cluster.adapt(minimum=1, maximum=10)\n",
-    "    cluster\n",
-    "\n",
+    "    cluster.adapt(minimum=4, maximum=10)\n",
     "    client = cluster.get_client()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cluster.shutdown()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "gateway.list_clusters()"
    ]
   },
   {
@@ -109,6 +136,15 @@
     "sample_model_path = (\n",
     "    \"s3://carbonplan-climatetrace/v1/models/xgb_biomass_50N_120W.bin\"\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_credentials(aws_session)"
    ]
   },
   {
@@ -173,28 +209,51 @@
     "if rerun:\n",
     "    with rio.Env(aws_session):\n",
     "        for year in np.arange(2003, 2004):\n",
-    "            for [path, row] in sample_tile[[\"PATH\", \"ROW\"]].values[0:1]:\n",
-    "                #                 tasks.append(\n",
-    "                predict(\n",
-    "                    sample_model_path,\n",
-    "                    path,\n",
-    "                    row,\n",
-    "                    year,\n",
-    "                    access_key_id,\n",
-    "                    secret_access_key,\n",
-    "                    output_write_bucket=\"/\".join(\n",
-    "                        [\n",
-    "                            bucket,\n",
-    "                            \"inference\",\n",
-    "                            str(path),\n",
-    "                            str(row),\n",
-    "                            str(year),\n",
-    "                            \"data.parquet\",\n",
-    "                        ]\n",
-    "                    ),\n",
-    "                    input_write_bucket=None,  #'/'.join([bucket, 'inference', 'test_inputs.parquet'])\n",
-    "                )\n",
-    "#                 )"
+    "            for [path, row] in sample_tile[[\"PATH\", \"ROW\"]].values:\n",
+    "                tasks.append(\n",
+    "                    #                                     predict(\n",
+    "                    predict_delayed(\n",
+    "                        sample_model_path,\n",
+    "                        path,\n",
+    "                        row,\n",
+    "                        year,\n",
+    "                        access_key_id,\n",
+    "                        secret_access_key,\n",
+    "                        #                     aws_session,\n",
+    "                        output_write_bucket=\"/\".join(\n",
+    "                            [\n",
+    "                                bucket,\n",
+    "                                \"inference\",\n",
+    "                                str(path),\n",
+    "                                str(row),\n",
+    "                                str(year),\n",
+    "                                \"data.parquet\",\n",
+    "                            ]\n",
+    "                        )\n",
+    "                        #                     input_write_bucket='/'.join([bucket, 'inference', 'test_inputs.parquet'])\n",
+    "                    )\n",
+    "                )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dask.compute(tasks)  # , retries=4, resources={'process': 1})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for task in tasks:\n",
+    "    task.cancel()"
    ]
   }
  ],


### PR DESCRIPTION
This PR shifts session/permissions-handling such that each worker gets the adequate permissions to read and write. These changes don't break the local cluster behavior (you can now just run either locally or on a remote- aka potentially bigger- cluster).

Also a change at L105 in `landsat_preprocess.py` to scale the reflectance values appropriately.
